### PR TITLE
Rebuild v2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   url: https://pypi.io/packages/source/{{ pip_name[0] }}/{{ pip_name }}/{{ pip_name }}-{{ version }}.tar.gz
 
 build:
-  number: 0
+  number: 1
   script:
     - export XXHASH_LINK_SO=1  # [unix]
     - SET XXHASH_LINK_SO=1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,8 @@ about:
   license_file: LICENSE
   license_url: https://github.com/ifduyue/python-xxhash/blob/v{{ version }}/LICENSE
   summary: Python binding for xxHash
+  description: |
+    Python binding for xxHash which is an extremely fast hash algorithm, processing at RAM speed limits. Code is highly portable, and produces hashes identical across all platforms (little / big endian).
   license_family: BSD
   doc_url: https://github.com/ifduyue/python-xxhash/tree/v{{ version }}
   doc_source_url: https://raw.githubusercontent.com/ifduyue/python-xxhash/v{{ version }}/README.rst

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,12 @@ about:
   home: https://github.com/ifduyue/python-xxhash
   license: BSD-2-Clause
   license_file: LICENSE
+  license_url: https://github.com/ifduyue/python-xxhash/blob/v{{ version }}/LICENSE
   summary: Python binding for xxHash
   license_family: BSD
+  doc_url: https://github.com/ifduyue/python-xxhash/tree/v{{ version }}
+  doc_source_url: https://raw.githubusercontent.com/ifduyue/python-xxhash/v{{ version }}/README.rst
+  dev_url: https://github.com/ifduyue/python-xxhash/tree/v{{ version }}
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - python
     - msinttypes  # [win and py<35]
     - pip
+    - setuptools
+    - wheel
     - xxhash
   run:
     - python


### PR DESCRIPTION
Rebuild `python-xxhash` `v2.0.2` to add support for osx-arm.

- Bumps build number 
- Update about section
- Add `setuptools` and `wheel`

`datasets`  -> `python-xxhash`